### PR TITLE
Fix delete_poster failing for locally uploaded posters (issue #2)

### DIFF
--- a/src/tools/posters.ts
+++ b/src/tools/posters.ts
@@ -134,7 +134,11 @@ export async function deletePoster(
 
     // First check if this is the selected poster
     const posters = await client.getPosters(args.ratingKey);
-    const posterToDelete = posters.find((p) => p.key === args.posterKey);
+    // Match by key (full path) or ratingKey (upload:// URI) — both may be
+    // shown in list_posters output and users may pass either.
+    const posterToDelete = posters.find(
+      (p) => p.key === args.posterKey || p.ratingKey === args.posterKey
+    );
 
     if (!posterToDelete) {
       return createErrorResponse(new Error('Poster not found'));
@@ -148,7 +152,9 @@ export async function deletePoster(
       );
     }
 
-    await client.deletePoster(args.ratingKey, args.posterKey);
+    // Always pass the canonical key (full path) so deletePoster can pick the
+    // right endpoint, regardless of which identifier the user supplied.
+    await client.deletePoster(args.ratingKey, posterToDelete.key);
 
     return createResponse({
       message: 'Poster deleted successfully',


### PR DESCRIPTION
Two bugs were causing the failure:

1. posters.ts lookup only matched by p.key (the full internal path like /library/metadata/{id}/file?url=upload://...). Users passing the upload:// URI (visible as ratingKey in list_posters output) always got "Poster not found". Fix: match by p.key OR p.ratingKey, then always pass p.key (the canonical full path) to the client so it uses the right endpoint.

2. plex-client.ts was extracting the upload:// URI from the key and calling DELETE /library/metadata/{id}/posters?url=upload://... which Plex returns 404 for. Fix: when posterKey is a full path (starts with /), DELETE that path directly (/library/metadata/{id}/file?url=upload://...). Only use the /posters?url= form for external poster URLs (TMDB etc.).

https://claude.ai/code/session_0132g1NnUMBm2kkYuEBai31C

Title: Fix watched filter, add Plex Watchlist tools, fix delete_poster for local uploads

Commits on this branch:

af8f3ef — Fix watched filter being silently ignored in advancedSearch (was in schema but never applied to the API call)
682e65a — Add Plex Watchlist support (get_watchlist, add_to_watchlist, remove_from_watchlist)
43f6e84 — Update README to document Watchlist tools
98643b7 — Add search_plex_catalog + allow adding non-library items to watchlist via guid
887ccaf — Fix delete_poster failing for locally uploaded posters (issue #2) — two bugs: wrong lookup key in posters.ts, wrong delete endpoint in plex-client.ts